### PR TITLE
Add 1-click deploy to Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ local-server/
 *.pyc
 .dockerignore
 Dockerfile
+render.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,13 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY . /code/
 
-# Heroku uses PORT, Azure App Services uses WEBSITES_PORT, Fly.io uses 8080 by default
+ARG RENDER_EXTERNAL_HOSTNAME
+# This finds instances of the placeholder domain and replaces them with the actual domain
+RUN grep -rl "your-app-url.com" . | xargs sed -i "s/your-app-url.com/${RENDER_EXTERNAL_HOSTNAME}/g"
+
+# The Blueprint file can inject the hostname into the environment, but source code expects http://hostname format
+ARG WEAVIATE_HOSTNAME
+ENV WEAVIATE_HOST=http://${WEAVIATE_HOSTNAME}
+
+# Render and Heroku use PORT, Azure App Services uses WEBSITES_PORT, Fly.io uses 8080 by default
 CMD ["sh", "-c", "uvicorn server.main:app --host 0.0.0.0 --port ${PORT:-${WEBSITES_PORT:-8080}}"]

--- a/Dockerfile.weaviate
+++ b/Dockerfile.weaviate
@@ -1,0 +1,1 @@
+FROM semitechnologies/weaviate:1.18.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
-# ChatGPT Retrieval Plugin
+# ChatGPT Retrieval Plugin, Hosted on Render
+
+Fork this repo and click the button below to deploy your ChatGPT Retrieval
+Plugin server to [Render](https://render.com). You will be prompted to enter
+your OpenAI API key. The bearer token for your retrieval plugin server will be
+generated automatically. You can find it in the "Environment" tab on the [Render
+dashboard](https://dashboard.render.com) page for your server.
+
+<a href="https://render.com/deploy?repo=https://github.com/render-examples/chatgpt-retrieval-plugin/tree/main">
+<img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" />
+</a>
+<br><br>
+
+The [Render Blueprint](https://render.com/docs/blueprint-spec) in this repo at
+[render.yaml](render.yaml) configures the OpenAI Retrieval Plugin FastAPI server
+and a self-hosted [Weaviate](https://weaviate.io/) vector database to back it.
+As of April 2023, this setup costs $15 to run continuously for a month. The two
+services on Render's Starter plan cost $7/month each, and the 4 GB persistent
+disk attached to the Weaviate service costs $1/month. Check [Render's pricing
+page](https://render.com/pricing) for up-to-date pricing information.
+
+You might want to scale up to a larger plan or to horizontally scale the FastAPI
+server. Consult Weaviate's [resource planning
+doc](https://weaviate.io/developers/weaviate/concepts/resources) for more
+guidance. The FastAPI server is compatible with [Render's free
+plan](https://render.com/docs/free) but the Weaviate database is not because it
+has a disk. This Blueprint can be adapted to support [other compatible
+datastores](https://github.com/openai/chatgpt-retrieval-plugin#choosing-a-vector-database)
+besides Weaviate.
+
+---
 
 > **Join the [ChatGPT plugins waitlist here](https://openai.com/waitlist/plugins)!**
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,47 @@
+services:
+  # FastAPI Server
+  - type: web
+    name: retrieval-plugin-server 
+    region: oregon
+    plan: starter
+    env: docker
+    dockerfilePath: ./Dockerfile
+    envVars: 
+      - key: DATASTORE
+        value: weaviate
+      - key: BEARER_TOKEN
+        generateValue: true 
+      # will be promtped to add this in the UI on deployment
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: WEAVIATE_HOSTNAME
+        fromService:
+          type: pserv
+          name: weaviate
+          property: host
+      - key: WEAVIATE_PORT
+        value: 8080
+
+  # Weaviate vector database
+  - type: pserv
+    name: weaviate
+    region: oregon
+    plan: starter
+    env: docker
+    dockerfilePath: ./Dockerfile.weaviate
+    autoDeploy: false
+    disk:
+      name: weaviate-data
+      mountPath: /var/lib/weaviate
+      sizeGB: 4
+    envVars:
+      - key: QUERY_DEFAULTS_LIMIT
+        value: 25
+      - key: AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED
+        value: true
+      - key: PERSISTENCE_DATA_PATH
+        value: /var/lib/weaviate
+      - key: DEFAULT_VECTORIZER_MODULE
+        value: none
+      - key: CLUSTER_HOSTNAME
+        value: node1


### PR DESCRIPTION
1-click deploy for https://github.com/openai/chatgpt-retrieval-plugin with self-hosted weaviate as the datastore. I'll update to postgres + pgvector once https://github.com/openai/chatgpt-retrieval-plugin/pull/45 is merged since the managed db experience will be smoother.

I thought about using a separate repo so we don't have to maintain this fork, but the logic I added to the Dockerfile seemed awkward to express as a one-line start command override. We may be able to generalize and upstream that logic later, which would simplify things.